### PR TITLE
Changed main to index.coffee

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coffeelint-camel-case-vars",
   "version": "0.0.4",
   "description": "A CoffeeLint rule that ensures variables are camelCased",
-  "main": "index.js",
+  "main": "index.coffee",
   "repository": {
     "type": "git",
     "url": "git://github.com/bsklaroff/coffeelint-camel-case-vars.git"


### PR DESCRIPTION
The npm module does not install index.js so it makes sense to just point this to index.coffee. It prevents this rule from crashing atom-coffeelint.
